### PR TITLE
Replaced all uses of `tibble_pole()` with `tibble()` in light of new update

### DIFF
--- a/R/methods-ade4-nipals.r
+++ b/R/methods-ade4-nipals.r
@@ -55,7 +55,7 @@ recover_conference.nipals <- function(x) {
 recover_aug_rows.nipals <- function(x) {
   name <- rownames(x[["li"]])
   if (is.null(name)) {
-    tibble_pole(nrow(x[["li"]]))
+    tibble(.rows = nrow(x[["li"]]))
   } else {
     tibble(name = name)
   }
@@ -66,7 +66,7 @@ recover_aug_rows.nipals <- function(x) {
 recover_aug_cols.nipals <- function(x) {
   name <- rownames(x[["c1"]])
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x[["c1"]]))
+    tibble(.rows = nrow(x[["c1"]]))
   } else {
     tibble(name = name)
   }

--- a/R/methods-ca-ca.r
+++ b/R/methods-ca-ca.r
@@ -51,7 +51,7 @@ recover_coord.ca <- function(x) {
 recover_aug_rows.ca <- function(x) {
   name <- rownames(x$rowcoord)
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$rowcoord))
+    tibble(.rows = nrow(x$rowcoord))
   } else {
     tibble(name = name)
   }
@@ -68,7 +68,7 @@ recover_aug_rows.ca <- function(x) {
 recover_aug_cols.ca <- function(x) {
   name <- rownames(x$colcoord)
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$colcoord))
+    tibble(.rows = nrow(x$colcoord))
   } else {
     tibble(name = name)
   }

--- a/R/methods-ca-mjca.r
+++ b/R/methods-ca-mjca.r
@@ -59,7 +59,7 @@ recover_coord.mjca <- function(x) paste0("Dim", seq(ncol(x$rowcoord)))
 recover_aug_rows.mjca <- function(x) {
   name <- x$rownames
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$rowcoord))
+    tibble(.rows = nrow(x$rowcoord))
   } else {
     tibble(name = name)
   }
@@ -76,7 +76,7 @@ recover_aug_rows.mjca <- function(x) {
 recover_aug_cols.mjca <- function(x){
   name <- x$levelnames
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$colcoord))
+    tibble(.rows = nrow(x$colcoord))
   } else {
     tibble(name = name)
   }

--- a/R/methods-candisc-cancor.r
+++ b/R/methods-candisc-cancor.r
@@ -91,7 +91,7 @@ recover_supp_cols.cancor <- function(x) {
 recover_aug_rows.cancor <- function(x) {
   name <- x$names$X
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$coef$X))
+    tibble(.rows = nrow(x$coef$X))
   } else {
     tibble(name = name)
   }
@@ -101,7 +101,7 @@ recover_aug_rows.cancor <- function(x) {
   res_sup <- NULL
   if (! is.null(x$scores$X)) {
     res_sup_elt <- if (is.null(rownames(x$scores$X))) {
-      tibble_pole(nrow(x$scores$X))
+      tibble(.rows = nrow(x$scores$X))
     } else {
       tibble(name = rownames(x$scores$X))
     }
@@ -110,7 +110,7 @@ recover_aug_rows.cancor <- function(x) {
   }
   if (! is.null(x$structure$X.xscores)) {
     res_sup_elt <- if (is.null(rownames(x$structure$X.xscores))) {
-      tibble_pole(nrow(x$structure$X.xscores))
+      tibble(.rows = nrow(x$structure$X.xscores))
     } else {
       tibble(name = rownames(x$structure$X.xscores))
     }
@@ -126,7 +126,7 @@ recover_aug_rows.cancor <- function(x) {
 recover_aug_cols.cancor <- function(x) {
   name <- x$names$Y
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$coef$Y))
+    tibble(.rows = nrow(x$coef$Y))
   } else {
     tibble(name = name)
   }
@@ -136,7 +136,7 @@ recover_aug_cols.cancor <- function(x) {
   res_sup <- NULL
   if (! is.null(x$scores$Y)) {
     res_sup_elt <- if (is.null(rownames(x$scores$Y))) {
-      tibble_pole(nrow(x$scores$Y))
+      tibble(.rows = nrow(x$scores$Y))
     } else {
       tibble(name = rownames(x$scores$Y))
     }
@@ -145,7 +145,7 @@ recover_aug_cols.cancor <- function(x) {
   }
   if (! is.null(x$structure$Y.yscores)) {
     res_sup_elt <- if (is.null(rownames(x$structure$Y.yscores))) {
-      tibble_pole(nrow(x$structure$Y.yscores))
+      tibble(.rows = nrow(x$structure$Y.yscores))
     } else {
       tibble(name = rownames(x$structure$Y.yscores))
     }

--- a/R/methods-logisticpca-clpca.r
+++ b/R/methods-logisticpca-clpca.r
@@ -42,7 +42,7 @@ recover_coord.clpca <- function(x) paste0("LPC", 1:ncol(x$U))
 recover_aug_rows.clpca <- function(x) {
   name <- rownames(x$PCs)
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$PCs))
+    tibble(.rows = nrow(x$PCs))
   } else {
     tibble(name = name)
   }
@@ -54,7 +54,7 @@ recover_aug_rows.clpca <- function(x) {
 recover_aug_cols.clpca <- function(x) {
   name <- rownames(x$U)
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$U))
+    tibble(.rows = nrow(x$U))
   } else {
     tibble(name = name)
   }

--- a/R/methods-logisticpca-lpca.r
+++ b/R/methods-logisticpca-lpca.r
@@ -49,7 +49,7 @@ recover_coord.lpca <- function(x) paste0("LPC", 1:ncol(x$U))
 recover_aug_rows.lpca <- function(x) {
   name <- rownames(x$PCs)
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$PCs))
+    tibble(.rows = nrow(x$PCs))
   } else {
     tibble(name = name)
   }
@@ -61,7 +61,7 @@ recover_aug_rows.lpca <- function(x) {
 recover_aug_cols.lpca <- function(x) {
   name <- rownames(x$U)
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$U))
+    tibble(.rows = nrow(x$U))
   } else {
     tibble(name = name)
   }

--- a/R/methods-logisticpca-lsvd.r
+++ b/R/methods-logisticpca-lsvd.r
@@ -48,7 +48,7 @@ recover_coord.lsvd <- function(x) paste0("LSC", 1:ncol(x$A))
 recover_aug_rows.lsvd <- function(x) {
   name <- rownames(x$A)
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$A))
+    tibble(.rows = nrow(x$A))
   } else {
     tibble(name = name)
   }
@@ -60,7 +60,7 @@ recover_aug_rows.lsvd <- function(x) {
 recover_aug_cols.lsvd <- function(x) {
   name <- rownames(x$B)
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$B))
+    tibble(.rows = nrow(x$B))
   } else {
     tibble(name = name)
   }

--- a/R/methods-nipals-empca.r
+++ b/R/methods-nipals-empca.r
@@ -46,7 +46,7 @@ recover_conference.empca_ord <- function(x) {
 recover_aug_rows.empca_ord <- function(x) {
   name <- rownames(x[["scores"]])
   if (is.null(name)) {
-    tibble_pole(nrow(x[["scores"]]))
+    tibble(.rows = nrow(x[["scores"]]))
   } else {
     tibble(name = name)
   }
@@ -57,7 +57,7 @@ recover_aug_rows.empca_ord <- function(x) {
 recover_aug_cols.empca_ord <- function(x) {
   name <- rownames(x[["loadings"]])
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x[["loadings"]]))
+    tibble(.rows = nrow(x[["loadings"]]))
   } else {
     tibble(name = name)
   }

--- a/R/methods-nipals-nipals.r
+++ b/R/methods-nipals-nipals.r
@@ -46,7 +46,7 @@ recover_conference.nipals_ord <- function(x) {
 recover_aug_rows.nipals_ord <- function(x) {
   name <- rownames(x[["scores"]])
   if (is.null(name)) {
-    tibble_pole(nrow(x[["scores"]]))
+    tibble(.rows = nrow(x[["scores"]]))
   } else {
     tibble(name = name)
   }
@@ -57,7 +57,7 @@ recover_aug_rows.nipals_ord <- function(x) {
 recover_aug_cols.nipals_ord <- function(x) {
   name <- rownames(x[["loadings"]])
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x[["loadings"]]))
+    tibble(.rows = nrow(x[["loadings"]]))
   } else {
     tibble(name = name)
   }

--- a/R/methods-pma-cca.r
+++ b/R/methods-pma-cca.r
@@ -65,7 +65,7 @@ recover_conference.CCA <- function(x) {
 recover_aug_rows.CCA <- function(x) {
   name <- x$xnames
   if (is.null(name)) {
-    tibble_pole(nrow(x$u))
+    tibble(.rows = nrow(x$u))
   } else {
     tibble(name = name)
   }
@@ -76,7 +76,7 @@ recover_aug_rows.CCA <- function(x) {
 recover_aug_cols.CCA <- function(x) {
   name <- x$znames
   if (is.null(name)) {
-    tibble_pole(nrow(x$v))
+    tibble(.rows = nrow(x$v))
   } else {
     tibble(name = name)
   }

--- a/R/methods-pma-spc.r
+++ b/R/methods-pma-spc.r
@@ -66,7 +66,7 @@ recover_conference.SPC <- function(x) {
 recover_aug_rows.SPC <- function(x) {
   name <- x$rnames
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$u))
+    tibble(.rows = nrow(x$u))
   } else {
     tibble(name = name)
   }
@@ -81,7 +81,7 @@ recover_aug_rows.SPC <- function(x) {
 recover_aug_cols.SPC <- function(x) {
   name <- x$cnames
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x$v))
+    tibble(.rows = nrow(x$v))
   } else {
     tibble(name = name)
   }

--- a/R/methods-psych-principal.R
+++ b/R/methods-psych-principal.R
@@ -65,12 +65,12 @@ recover_supp_rows.principal <- function(x) {
 #' @rdname methods-principal
 #' @export
 recover_aug_rows.principal <- function(x) {
-  res <- tibble_pole(nrow = 0L)
+  res <- tibble(.rows = 0L)
   
   # scores as supplementary points
   name <- rownames(x[["scores"]])
   res_sup <- if (is.null(name)) {
-    tibble_pole(nrow = nrow(x[["scores"]]))
+    tibble(.rows = nrow(x[["scores"]]))
   } else {
     tibble(name = name)
   }
@@ -86,7 +86,7 @@ recover_aug_rows.principal <- function(x) {
 recover_aug_cols.principal <- function(x) {
   name <- rownames(x[["loadings"]])
   res <- if (is.null(name)) {
-    tibble_pole(nrow(x[["loadings"]]))
+    tibble(.rows = nrow(x[["loadings"]]))
   } else {
     tibble(name = name)
   }


### PR DESCRIPTION
Hi @corybrunson. I've gone ahead and removed all lines containing the `tibble_pole()` function, replacing them with `tibble()`. For each replacement, I compared the output of the corresponding example script to what was produced prior to the revision. All of the outputs remained the same except for the script corresponding to `nipals::empca()`, which seemed to be rounding a bit differently but with no drastic changes. Still, I'm not sure why this would happen. Additionally, I ran all unit tests and all were passed. Let me know if there's anything else I can do here!