### PR TITLE
Updated recover_aug_cols.fa() to take the transposed pseudoinverse of the weights matrix

### DIFF
--- a/R/methods-psych-fa.R
+++ b/R/methods-psych-fa.R
@@ -68,7 +68,8 @@ recover_supp_rows.fa <- function(x) {
 #' @rdname methods-fa
 #' @export
 recover_supp_cols.fa <- function(x) {
-  x[["weights"]]
+  solve(t(x[["weights"]]) %*% x[["weights"]]) %*% t(x[["weights"]]) |>
+    t()
 }
 
 #' @rdname methods-fa
@@ -107,7 +108,7 @@ recover_aug_cols.fa <- function(x) {
   res$.element <- "active"
   res <- res[c(".element", setdiff(names(res), ".element"))]  # reorder columns
   
-  # weights as supplementary points
+  # transposed pseudoinverse of weights as supplementary points
   name <- rownames(x[["weights"]])
   res_sup <- if (is.null(name)) {
     tibble(.rows = nrow(x[["weights"]]))

--- a/man/methods-fa.Rd
+++ b/man/methods-fa.Rd
@@ -63,12 +63,34 @@ them. When computed and returned by \code{\link[psych:fa]{psych::fa()}}, the cas
 accessible as supplementary elements. Redistribution of inertia commutes
 through both score calculations.
 }
+\examples{
+# data frame of Swiss fertility and socioeconomic indicators
+class(swiss)
+head(swiss)
+# perform factor analysis
+swiss_fa <- psych::fa(r = swiss, nfactors = 2L, rotate = "varimax", scores = "regression", 
+               fm = "ml")
+
+# wrap as a 'tbl_ord' object
+(swiss_fa <- as_tbl_ord(swiss_fa))
+
+# recover loadings
+get_cols(swiss_fa, elements = "active")
+# recover scores
+head(get_rows(swiss_fa, elements = "score"))
+
+# augment column loadings with uniquenesses
+(swiss_fa <- augment_ord(swiss_fa))
+}
 \seealso{
 Other methods for eigen-decomposition-based techniques: 
 \code{\link{methods-principal}}
 
 Other models from the psych package: 
 \code{\link{methods-principal}}
+}
+\author{
+John Gracey
 }
 \concept{methods for eigen-decomposition-based techniques}
 \concept{models from the psych package}

--- a/man/wrap-ord-extra.Rd
+++ b/man/wrap-ord-extra.Rd
@@ -115,7 +115,7 @@ If it is not converging, try \code{ss_factor = 1}.}
 \item{maxiter}{Maximum number of NIPALS iterations for each
 principal component.}
 
-\item{tol}{Default 1e-9 tolerance for testing convergence of the NIPALS
+\item{tol}{Default 1e-6 tolerance for testing convergence of the NIPALS
 iterations for each principal component.}
 
 \item{startcol}{Determine the starting column of x for the iterations


### PR DESCRIPTION
Hi @corybrunson. This change to the `psych::fa()` methods takes the transposed pseudoinverse of the weights matrix as supplementary columns rather than the weights matrix itself. This is because the pseudoinverse carries the same amount of inertia as the active columns (unlike the weights themselves) and the transposed pseudoinverse is the column element in the decomposition of X with the scores as we discussed (I explained this in greater detail in the vignette). The examples and unit tests all run smoothly with these changes, and I got no errors from `devtools::check()`!