### PR TITLE
Attempted to fix ordering of principal components in biplot with 10+ PCs

### DIFF
--- a/R/methods-psych-principal.R
+++ b/R/methods-psych-principal.R
@@ -97,8 +97,12 @@ recover_aug_cols.principal <- function(x) {
 #' @rdname methods-principal
 #' @export
 recover_aug_coord.principal <- function(x) {
+  names <- colnames(x[["loadings"]])
+  num <- order(as.numeric(sub("PC", "", names)))
+  ordered_names <- names[num]
+  
   data.frame(
-    name = recover_coord.principal(x),
-    sdev = sqrt(x[["values"]][seq(1, ncol(x[["loadings"]]))])
+    name = factor(ordered_names, levels = ordered_names),
+    sdev = sqrt(x[["values"]])[num]
   )
 }

--- a/R/methods-psych-principal.R
+++ b/R/methods-psych-principal.R
@@ -97,12 +97,7 @@ recover_aug_cols.principal <- function(x) {
 #' @rdname methods-principal
 #' @export
 recover_aug_coord.principal <- function(x) {
-  names <- colnames(x[["loadings"]])
-  num <- order(as.numeric(sub("PC", "", names)))
-  ordered_names <- names[num]
-  
-  data.frame(
-    name = factor(ordered_names, levels = ordered_names),
-    sdev = sqrt(x[["values"]])[num]
+  tibble(
+    name = factor_coord(recover_coord(x))
   )
 }

--- a/sandbox/reoder-factors-psych-principal.R
+++ b/sandbox/reoder-factors-psych-principal.R
@@ -1,0 +1,11 @@
+library(ordr)
+library(ordr.extra)
+library(psych)
+library(tibble)
+
+hcw_pca <- ordinate(hcw[36:49], ~principal(., nfactors = 14, rotate = "none"))
+
+tidy(hcw_pca) |>
+  ggplot(aes(x = name,y = inertia))
+
+recover_coord(hcw_pca)

--- a/sandbox/reoder-factors-psych-principal.R
+++ b/sandbox/reoder-factors-psych-principal.R
@@ -3,9 +3,18 @@ library(ordr.extra)
 library(psych)
 library(tibble)
 
+# create PCA object with healthcare worker data
 hcw_pca <- ordinate(hcw[36:49], ~principal(., nfactors = 14, rotate = "none"))
 
+# generate blank scree plot to see order of PCs on x-axis
 tidy(hcw_pca) |>
   ggplot(aes(x = name,y = inertia))
 
-recover_coord(hcw_pca)
+# inspect output of recover_aug_coord
+recover_aug_coord(hcw_pca)
+
+# The ordering of the "name" column in `recover_aug_coord(hcw_pca)` is what we
+# want -- ordered by the number following "PC". However, this was the case when
+# printing the output before my changes, too. The biplot axis is still wrong, 
+# though. I tried reading the documentation and some source code for ggplot, but
+# couldn't come up with anything there.

--- a/sandbox/reoder-factors-psych-principal.R
+++ b/sandbox/reoder-factors-psych-principal.R
@@ -18,3 +18,17 @@ recover_aug_coord(hcw_pca)
 # printing the output before my changes, too. The biplot axis is still wrong, 
 # though. I tried reading the documentation and some source code for ggplot, but
 # couldn't come up with anything there.
+
+# compare these results to the analogous results for `psych::fa()`, for which we
+# used `factor_coord()` in the augmented coordinate recoverer.
+
+# create FA object with healthcare worker data (use 12, not 14 factors b/c of 
+# nfactor constraint from the function)
+hcw_fa <- ordinate(hcw[36:49], ~fa(., nfactors = 12, rotate = "none"))
+
+# generate blank scree plot to see order of PCs on x-axis
+tidy(hcw_fa) |>
+  ggplot(aes(x = name,y = inertia))
+
+# the factors on the scree plot are ordered as desired, indicating 
+# `factor_coord()` resolves the issue from `recover_aug_coord()`.

--- a/sandbox/reoder-factors-psych-principal.R
+++ b/sandbox/reoder-factors-psych-principal.R
@@ -15,7 +15,7 @@ recover_aug_coord(hcw_pca)
 
 # The ordering of the "name" column in `recover_aug_coord(hcw_pca)` is what we
 # want -- ordered by the number following "PC". However, this was the case when
-# printing the output before my changes, too. The biplot axis is still wrong, 
+# printing the output before my changes, too. The scree plot axis is still wrong, 
 # though. I tried reading the documentation and some source code for ggplot, but
 # couldn't come up with anything there.
 
@@ -32,3 +32,19 @@ tidy(hcw_fa) |>
 
 # the factors on the scree plot are ordered as desired, indicating 
 # `factor_coord()` resolves the issue from `recover_aug_coord()`.
+
+# now, implement the fix into the `psych::principal()` methods and test.
+
+recover_aug_coord.principal <- function(x) {
+  tibble(
+    name = factor_coord(recover_coord(x))
+  )
+}
+
+hcw_pca <- ordinate(hcw[36:49], ~principal(., nfactors = 14, rotate = "none"))
+
+# generate blank scree plot to see order of PCs on x-axis
+tidy(hcw_pca) |>
+  ggplot(aes(x = name,y = inertia))
+
+# the scree plot axis still has the wrong order of PCs

--- a/sandbox/reoder-factors-psych-principal.R
+++ b/sandbox/reoder-factors-psych-principal.R
@@ -1,5 +1,5 @@
 library(ordr)
-library(ordr.extra)
+devtools::load_all()
 library(psych)
 library(tibble)
 


### PR DESCRIPTION
Hi @corybrunson. Based on the issue I ran into while making my latest research poster, I am trying to make the output of `recover_aug_coord.principal()` such that the elements on the x-axis of the biplot are ordered by the numeric value following "PC". I attempted to do this by reindexing the names column, then taking the names as factors. I illustrated this in a new sandbox script. However, I wasn't successful. Do you have any tips?